### PR TITLE
Add Claude Enterprise tech blog and update skills

### DIFF
--- a/constants/skills.ts
+++ b/constants/skills.ts
@@ -15,12 +15,11 @@ const skills = [
     ],
   },
   {
-    header: 'Infrastracture as Codeの実現',
+    header: 'Infrastructure as Codeの実現',
     content: [
-      'Infrastracture as Codeによる利点と恩恵を考慮した上で、管理/変更/レビュー/運用のしやすいInfrastracture as Codeな世界を実現することができます。',
+      'Infrastructure as Codeによる利点と恩恵を考慮した上で、管理/変更/レビュー/運用のしやすいInfrastructure as Codeな世界を実現することができます。',
       'ツールとしてはTerraformを利用することが多いですが、CloudFormationによる実装経験もあります。',
-      'Terraformに関してはTerraform Cloudによるplan/applyの自動化や、AWS/GCP以外にGitHubやTerraform Cloud自体の管理などヘビーに活用しています。',
-      '最近はGitHub Actionsでplan/applyの自動実行なども行うことがあります。',
+      'Terraform CloudでのCI/CD自動化を経て、現在はコストと開発体験の観点からGitHub Actions上でのplan/apply自動実行に全面移行して運用しています。AWS/GCPに加え、GitHub自体の管理などにも活用しています。',
     ],
   },
   {
@@ -30,6 +29,7 @@ const skills = [
       '特に複数のAWSアカウントを横断したOrganizationやCloudTrail、SecurityHubを用いた一元的なセキュリティ対策と検知の仕組みの構築を推奨しております。',
       'セキュリティKPIの策定と月次レビュー体制の確立、セキュリティロードマップの策定など、組織のセキュリティを継続的に改善する仕組みづくりも担当しています。',
       'ログ改ざん耐性の確保やDB監査ログの取得など、実践的なセキュリティ対策の構築経験もあります。',
+      'サプライチェーン攻撃に対しては、依存バージョンの固定・SASTの導入・CI/CDのハードニングなど、予防的な仕組みを複数リポジトリへ横展開しています。',
     ],
   },
   {
@@ -57,6 +57,13 @@ const skills = [
     content: [
       'Webアプリケーションエンジニア時代から負荷試験や性能改善等を業務で担当してきました。',
       'APMやモニタリングツールやプロファイラーを利用した本番環境やCI上のボトルネックの特定と、WebアプリケーションやRDBMSやLinux OSの知識を活用しパフォーマンス改善を行うことができます。',
+    ],
+  },
+  {
+    header: '可観測性(Observability)基盤の構築',
+    content: [
+      'メトリクス・ログ・トレースを組み合わせた可観測性基盤の設計・構築ができます。',
+      'Amazon Managed Prometheus / GrafanaやOpenTelemetry(ADOT)などのマネージドサービスを活用し、コスト帰属・異常検知・セキュリティ監査の土台となる基盤を本番構築した経験があります。',
     ],
   },
   {
@@ -140,7 +147,8 @@ const skills = [
     header: 'AIを活用した開発と仕組みづくり',
     content: [
       'AIエージェントを活用した開発（AI駆動開発）に日常的に取り組んでいます。',
-      'AIによって変化し続ける開発の在り方に対して、SRE / セキュリティの知見を活かしたガードレールやポリシー・仕組みづくりに関心があります。',
+      '社内規約を組み込んだClaude Codeのプラグインや、Datadog/Notion/AWS Cost ExplorerなどのMCP統合、リポジトリ横断作業のためのマルチエージェント制御など、AIを活用した開発基盤の整備を進めてきました。',
+      'AIによって変化し続ける開発の在り方に対して、SRE / セキュリティの知見を活かしたガードレールやポリシー・仕組みづくりに関心があり、Claude Enterpriseの全社導入におけるセキュリティ設計なども担当しています。',
       'チーム全体でAIエージェントが安全かつ効果的に動作する環境を整備していくことを志向しています。',
     ],
   },

--- a/pages/articles.vue
+++ b/pages/articles.vue
@@ -5,6 +5,27 @@
     <v-row>
       <v-col cols="12" sm="6">
         <v-card
+          href="https://tech.medpeer.co.jp/entry/2026/06/26/122446"
+          target="_blank"
+        >
+          <v-img
+            src="https://ogimage.blog.st-hatena.com/8454420450089458396/14945776032045239896/1782444286"
+            height="300"
+          ></v-img>
+          <v-card-title>
+            Claude Enterprise全社導入で何を検討し、何をやらなかったか
+          </v-card-title>
+          <v-card-text>
+            メドピア開発者ブログに寄稿した、Claude
+            Enterprise全社導入の検討記事です
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col cols="12" sm="6">
+        <v-card
           href="https://aws.amazon.com/jp/builders-flash/202211/best-practice-game-day/"
           target="_blank"
         >

--- a/test/pages/__snapshots__/articles.test.js.snap
+++ b/test/pages/__snapshots__/articles.test.js.snap
@@ -5,6 +5,20 @@ exports[`articles should be vue instance 1`] = `
   <page-title-stub title=\\"Article\\"></page-title-stub>
   <v-row-stub tag=\\"div\\">
     <v-col-stub cols=\\"12\\" sm=\\"6\\" tag=\\"div\\">
+      <v-card-stub loaderheight=\\"4\\" href=\\"https://tech.medpeer.co.jp/entry/2026/06/26/122446\\" tag=\\"div\\" target=\\"_blank\\">
+        <v-img-stub height=\\"300\\" options=\\"[object Object]\\" position=\\"center center\\" src=\\"https://ogimage.blog.st-hatena.com/8454420450089458396/14945776032045239896/1782444286\\" transition=\\"fade-transition\\"></v-img-stub>
+        <v-card-title-stub tag=\\"div\\">
+          Claude Enterprise全社導入で何を検討し、何をやらなかったか
+        </v-card-title-stub>
+        <v-card-text-stub tag=\\"div\\">
+          メドピア開発者ブログに寄稿した、Claude
+          Enterprise全社導入の検討記事です
+        </v-card-text-stub>
+      </v-card-stub>
+    </v-col-stub>
+  </v-row-stub>
+  <v-row-stub tag=\\"div\\">
+    <v-col-stub cols=\\"12\\" sm=\\"6\\" tag=\\"div\\">
       <v-card-stub loaderheight=\\"4\\" href=\\"https://aws.amazon.com/jp/builders-flash/202211/best-practice-game-day/\\" tag=\\"div\\" target=\\"_blank\\">
         <v-img-stub height=\\"300\\" options=\\"[object Object]\\" position=\\"center center\\" src=\\"https://d1.awsstatic.com/Developer%20Marketing/jp/magazine/2022/thumb_best-practice-game-day.e8c956b14c26eb1cb52e08a998ac38544517f23d.jpg\\" transition=\\"fade-transition\\"></v-img-stub>
         <v-card-title-stub tag=\\"div\\">

--- a/test/pages/__snapshots__/skill.test.js.snap
+++ b/test/pages/__snapshots__/skill.test.js.snap
@@ -20,12 +20,11 @@ exports[`skills should be vue instance 1`] = `
       </v-expansion-panel-content-stub>
     </v-expansion-panel-stub>
     <v-expansion-panel-stub>
-      <v-expansion-panel-header-stub expandicon=\\"$expand\\" class=\\"title\\">Infrastracture as Codeの実現</v-expansion-panel-header-stub>
+      <v-expansion-panel-header-stub expandicon=\\"$expand\\" class=\\"title\\">Infrastructure as Codeの実現</v-expansion-panel-header-stub>
       <v-expansion-panel-content-stub>
-        <p>Infrastracture as Codeによる利点と恩恵を考慮した上で、管理/変更/レビュー/運用のしやすいInfrastracture as Codeな世界を実現することができます。</p>
+        <p>Infrastructure as Codeによる利点と恩恵を考慮した上で、管理/変更/レビュー/運用のしやすいInfrastructure as Codeな世界を実現することができます。</p>
         <p>ツールとしてはTerraformを利用することが多いですが、CloudFormationによる実装経験もあります。</p>
-        <p>Terraformに関してはTerraform Cloudによるplan/applyの自動化や、AWS/GCP以外にGitHubやTerraform Cloud自体の管理などヘビーに活用しています。</p>
-        <p>最近はGitHub Actionsでplan/applyの自動実行なども行うことがあります。</p>
+        <p>Terraform CloudでのCI/CD自動化を経て、現在はコストと開発体験の観点からGitHub Actions上でのplan/apply自動実行に全面移行して運用しています。AWS/GCPに加え、GitHub自体の管理などにも活用しています。</p>
       </v-expansion-panel-content-stub>
     </v-expansion-panel-stub>
     <v-expansion-panel-stub>
@@ -35,6 +34,7 @@ exports[`skills should be vue instance 1`] = `
         <p>特に複数のAWSアカウントを横断したOrganizationやCloudTrail、SecurityHubを用いた一元的なセキュリティ対策と検知の仕組みの構築を推奨しております。</p>
         <p>セキュリティKPIの策定と月次レビュー体制の確立、セキュリティロードマップの策定など、組織のセキュリティを継続的に改善する仕組みづくりも担当しています。</p>
         <p>ログ改ざん耐性の確保やDB監査ログの取得など、実践的なセキュリティ対策の構築経験もあります。</p>
+        <p>サプライチェーン攻撃に対しては、依存バージョンの固定・SASTの導入・CI/CDのハードニングなど、予防的な仕組みを複数リポジトリへ横展開しています。</p>
       </v-expansion-panel-content-stub>
     </v-expansion-panel-stub>
     <v-expansion-panel-stub>
@@ -62,6 +62,13 @@ exports[`skills should be vue instance 1`] = `
       <v-expansion-panel-content-stub>
         <p>Webアプリケーションエンジニア時代から負荷試験や性能改善等を業務で担当してきました。</p>
         <p>APMやモニタリングツールやプロファイラーを利用した本番環境やCI上のボトルネックの特定と、WebアプリケーションやRDBMSやLinux OSの知識を活用しパフォーマンス改善を行うことができます。</p>
+      </v-expansion-panel-content-stub>
+    </v-expansion-panel-stub>
+    <v-expansion-panel-stub>
+      <v-expansion-panel-header-stub expandicon=\\"$expand\\" class=\\"title\\">可観測性(Observability)基盤の構築</v-expansion-panel-header-stub>
+      <v-expansion-panel-content-stub>
+        <p>メトリクス・ログ・トレースを組み合わせた可観測性基盤の設計・構築ができます。</p>
+        <p>Amazon Managed Prometheus / GrafanaやOpenTelemetry(ADOT)などのマネージドサービスを活用し、コスト帰属・異常検知・セキュリティ監査の土台となる基盤を本番構築した経験があります。</p>
       </v-expansion-panel-content-stub>
     </v-expansion-panel-stub>
     <v-expansion-panel-stub>
@@ -145,7 +152,8 @@ exports[`skills should be vue instance 1`] = `
       <v-expansion-panel-header-stub expandicon=\\"$expand\\" class=\\"title\\">AIを活用した開発と仕組みづくり</v-expansion-panel-header-stub>
       <v-expansion-panel-content-stub>
         <p>AIエージェントを活用した開発（AI駆動開発）に日常的に取り組んでいます。</p>
-        <p>AIによって変化し続ける開発の在り方に対して、SRE / セキュリティの知見を活かしたガードレールやポリシー・仕組みづくりに関心があります。</p>
+        <p>社内規約を組み込んだClaude Codeのプラグインや、Datadog/Notion/AWS Cost ExplorerなどのMCP統合、リポジトリ横断作業のためのマルチエージェント制御など、AIを活用した開発基盤の整備を進めてきました。</p>
+        <p>AIによって変化し続ける開発の在り方に対して、SRE / セキュリティの知見を活かしたガードレールやポリシー・仕組みづくりに関心があり、Claude Enterpriseの全社導入におけるセキュリティ設計なども担当しています。</p>
         <p>チーム全体でAIエージェントが安全かつ効果的に動作する環境を整備していくことを志向しています。</p>
       </v-expansion-panel-content-stub>
     </v-expansion-panel-stub>


### PR DESCRIPTION
## 概要
Article に注目記事を追加し、Skill を直近の実績に合わせて更新。

## 変更点
### Article (`pages/articles.vue`)
- テックブログ「Claude Enterprise全社導入で何を検討し、何をやらなかったか」(tech.medpeer.co.jp) を最上段に追加

### Skill (`constants/skills.ts`)
- IaC: 「Terraform Cloud → GitHub Actions への全面移行」に記述を整合（旧: TF Cloud主力/GHAはたまに、と矛盾していた）
- 誤字修正: `Infrastracture` → `Infrastructure`
- セキュリティ: サプライチェーン攻撃対策（依存固定・SAST・CI/CDハードニングの横展開）を追記
- AIを活用した開発: Claude Codeプラグイン/MCP統合/マルチエージェント制御/Claude Enterprise全社導入のセキュリティ設計を具体化
- 新項目「可観測性(Observability)基盤の構築」を追加

## 動作確認
- `yarn lint` 緑 / `yarn test` 全4パス（スナップショット更新済み） / `yarn generate` 成功（Node 16.14.0）
- 生成物で Article/Skill への反映を確認（画像URL・展開パネル本文はJSバンドル側で確認）