### PR TITLE
fix(ci): ワークフロー内の pnpm install から --ignore-scripts を削除

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: '16'
           cache: 'pnpm'
-      - run: pnpm install --ignore-scripts
+      - run: pnpm install
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm generate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '16'
           cache: 'pnpm'
-      - run: pnpm install --ignore-scripts
+      - run: pnpm install
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm generate


### PR DESCRIPTION
## 概要
- `deploy.yml` および `test.yml` 内の `pnpm install --ignore-scripts` によりビルド・SSR生成に必要なビルドスクリプト・依存モジュールのリンクが行われず、`pnpm generate` で `Error: Cannot find module 'ufo'` が発生してデプロイ結果が空/エラーになる不具合を修正しました。
- `--ignore-scripts` を取り除き、すべての依存モジュールが正しくセットアップされるように修正しました。