### PR TITLE
fix(deps): devDependencies に ufo を追加して Nuxt SSR エラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "stylus": "^0.59.0",
     "stylus-loader": "^3.0.2",
     "ts-jest": "^26",
+    "ufo": "^1.6.4",
     "vue": "2.7.16",
     "vue-jest": "^4.0.1",
     "vue-template-compiler": "2.7.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       ts-jest:
         specifier: ^26
         version: 26.5.6(jest@26.6.3)(typescript@4.2.4)
+      ufo:
+        specifier: ^1.6.4
+        version: 1.6.4
       vue:
         specifier: 2.7.16
         version: 2.7.16


### PR DESCRIPTION
## 概要
- pnpm の strict node_modules 構造下で、Nuxt v2 の SSR レンダラーが依存モジュール `ufo` を動的 require する際に `Cannot find module 'ufo'` が発生し、生成される静的ファイルが空/エラーになっていた不具合を修正しました。
- `package.json` の `devDependencies` に `ufo` を追加し、ローカルの `pnpm generate` でエラーが発生しないことを確認しました。