### PR TITLE
fix(index): prevent avatar icon from appearing before tile animation finishes

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,7 +6,7 @@
           <div id="grid" class="grid main-contents">
             <div v-for="i in 324" :key="i" :class="squareClass(i)"></div>
           </div>
-          <div v-show="showAvatar" class="avatar-overlay">
+          <div class="avatar-overlay">
             <v-avatar size="160" class="icon-avatar">
               <img src="/icon.png" alt="icon" />
             </v-avatar>
@@ -51,7 +51,7 @@ export default defineComponent({
         complete: () => {
           showAvatar.value = true
           anime({
-            targets: '.icon-avatar',
+            targets: '.avatar-overlay',
             scale: [0.3, 1],
             opacity: [0, 1],
             easing: 'easeOutBack',
@@ -162,6 +162,7 @@ export default defineComponent({
     display: flex;
     justify-content: center;
     align-items: center;
+    opacity: 0;
   }
 }
 </style>


### PR DESCRIPTION
## 概要
トップページにて、タイルの拡大・縮小アニメーション完了前にアバターアイコンが前面に表示されてしまっていた問題を修正しました。

## 変更内容
- `pages/index.vue` の `.avatar-overlay` に初期スタイル `opacity: 0` を追加
- `animejs` のアニメーション対象ターゲットを `.avatar-overlay` に統一

## 確認内容
- Playwright による連続フレーム撮影で、タイルアニメーション完了後に正しくアイコンが表示されることを確認
- `pnpm test` および `pnpm lint` がすべて正常終了することを確認