### PR TITLE
test: add Playwright E2E client error checks (#493)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,14 @@ jobs:
           version: 8.15.9
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm generate
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run Playwright E2E tests
+        run: pnpm test:e2e
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,7 @@ coverage
 .gemini/tmp/
 .gemini/history/
 static/screenshots/
+.pnpm-store
+test-results/
+playwright-report/
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,4 +15,5 @@ module.exports = {
     '<rootDir>/components/**/*.vue',
     '<rootDir>/pages/**/*.vue',
   ],
+  testPathIgnorePatterns: ['/node_modules/', '/test/e2e/'],
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,4 +2,4 @@ pre-commit:
   commands:
     lint:
       glob: "*.{js,ts,vue}"
-      run: yarn lintstaged
+      run: pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate": "nuxt generate && echo 'reireias.dev' > dist/CNAME",
     "benchmark": "node scripts/benchmark.js https://reireias.github.io $(git rev-parse HEAD)",
     "test": "jest",
+    "test:e2e": "playwright test",
     "prepare": "lefthook install"
   },
   "lint-staged": {
@@ -34,6 +35,7 @@
     "@nuxtjs/eslint-config": "^6.0.1",
     "@nuxtjs/eslint-config-typescript": "^6.0.1",
     "@nuxtjs/vuetify": "^1.12.1",
+    "@playwright/test": "^1.40.0",
     "@types/animejs": "^3.1.4",
     "@vue/composition-api": "^1.7.2",
     "@vue/test-utils": "^1.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './test/e2e',
+  timeout: 30000,
+  expect: {
+    timeout: 5000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npx http-server ./dist -p 3000',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/test/e2e/client-errors.spec.ts
+++ b/test/e2e/client-errors.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('E2E Client Error Check', () => {
+  const pages = ['/', '/profile', '/skill', '/job', '/articles', '/sandbox']
+
+  for (const pagePath of pages) {
+    test(`page ${pagePath} should load without console errors or 404 responses`, async ({
+      page,
+    }) => {
+      const consoleErrors: string[] = []
+      const failedRequests: string[] = []
+
+      // Track console errors
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          consoleErrors.push(msg.text())
+        }
+      })
+
+      // Track uncaught page exceptions
+      page.on('pageerror', (exception) => {
+        consoleErrors.push(exception.message)
+      })
+
+      // Track 404 / 500 failed network responses
+      page.on('response', (response) => {
+        if (response.status() >= 400) {
+          failedRequests.push(`${response.status()} ${response.url()}`)
+        }
+      })
+
+      const response = await page.goto(pagePath)
+      expect(response?.status()).toBeLessThan(400)
+
+      // Ensure page rendered body
+      await expect(page.locator('body')).toBeVisible()
+
+      // Assert no console errors or failed network requests
+      expect(consoleErrors).toEqual([])
+      expect(failedRequests).toEqual([])
+    })
+  }
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,9 @@
     ]
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "test/e2e",
+    "playwright.config.ts"
   ]
 }
+


### PR DESCRIPTION
## 概要

Issue #493 に対応し、Playwright を用いた E2E テストによるクライアントサイドのエラー検知機能を導入しました。

## 変更内容
- Playwright の設定ファイル (`playwright.config.ts`) の追加
- クライアントエラー（コンソールエラー、JavaScript例外、404/500レスポンスエラー）を全ページ対象に検証する E2E テスト (`test/e2e/client-errors.spec.ts`) の作成
- `package.json` に `test:e2e` スクリプトを追加
- Jest 設定 (`jest.config.js`) で `test/e2e/` を除外対象に設定
- GitHub Actions (`.github/workflows/test.yml`) に Playwright ブラウザのインストールおよび E2E テスト実行ステップを追加
- `lefthook.yml` の実行コマンド不整合を修正 (`yarn lintstaged` -> `pnpm lint-staged`)

Closes #493
