### PR TITLE
build(deps): pin and update GitHub Actions using pinact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -26,7 +26,7 @@ jobs:
       - run: pnpm test
       - run: pnpm generate
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -23,7 +23,7 @@ jobs:
       - run: pnpm test
       - run: pnpm generate
       - name: Cache Playwright Browsers
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -37,7 +37,7 @@ jobs:
       - name: Run Playwright E2E tests
         run: pnpm test:e2e
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION
## 概要
`pinact` を使用して GitHub Actions Workflow の Action バージョンを最新化し、コミット SHA ハッシュによる固定を行いました。

## 変更内容
- `actions/checkout`: v7.0.1
- `pnpm/action-setup`: v6.0.9
- `actions/setup-node`: v7.0.0
- `actions/cache`: v6.1.0
- `actions/upload-artifact`: v7.0.1
- `peaceiris/actions-gh-pages`: v4.1.0
