### PR TITLE
perf(ci): skip playwright browser download on github actions (#529)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,20 +52,8 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm generate
-      - name: Cache Playwright Browsers
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-      - name: Install Playwright OS Dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
       - name: Run Playwright E2E tests
-        run: pnpm test:e2e
+        run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm test:e2e
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Closes #529

Xの投稿（https://x.com/jiahan_c/status/2082299710577201216）に従い、GitHub-hosted runner にあらかじめインストールされているブラウザを利用することで、playwright install によるブラウザのダウンロード処理およびキャッシュ処理をスキップし、E2Eテスト CI の高速化を図ります。

### 変更内容
- `.github/workflows/test.yml` から Cache Playwright Browsers / Install Playwright Browsers / Install Playwright OS Dependencies ステップを削除
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` を付与して Playwright テストを実行