### PR TITLE
perf(e2e): use system chrome channel and skip browser download (#529)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,20 +52,8 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm generate
-      - name: Cache Playwright Browsers
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-      - name: Install Playwright OS Dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
       - name: Run Playwright E2E tests
-        run: pnpm test:e2e
+        run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm test:e2e
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,10 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chrome',
+      },
     },
   ],
   webServer: {


### PR DESCRIPTION
Closes #529

Playwrightの実行ブラウザとしてシステム標準インストール済みのChrome（`channel: "chrome"`）を使用するように統一し、CI（GitHub Actions）およびローカル環境でのブラウザダウンロード処理を全廃・スキップしました。

### 変更内容
1. `playwright.config.ts`: `projects.chromium` に `channel: "chrome"` を設定
2. `.github/workflows/test.yml`: `Cache Playwright Browsers` / `Install Playwright Browsers` / `Install Playwright OS Dependencies` ステップを削除し、`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` を指定してテスト実行