### PR TITLE
[CI/CD] test.ymlにStylelint・Knipによる静的解析ステップを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+      - run: pnpm lint:style
+      - run: pnpm nuxi prepare
+      - run: pnpm knip
 
   unit-test:
     runs-on: ubuntu-latest

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,7 +11,7 @@
     "selector-class-pattern": null,
     "no-descending-specificity": null,
     "rule-empty-line-before": null,
-    "color-function-notation": "legacy",
+    "color-function-notation": null,
     "alpha-value-notation": "number"
   }
 }

--- a/components/PageTitle.vue
+++ b/components/PageTitle.vue
@@ -24,7 +24,7 @@ export default defineComponent({
   font-size: 3.75rem;
   font-weight: 300;
   line-height: 3.75rem;
-  letter-spacing: -0.0083333333em;
+  letter-spacing: -0.0083em;
   margin-top: 30px;
   margin-bottom: 10px;
   color: rgb(var(--v-theme-primary));

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -88,7 +88,7 @@ export default defineComponent({
   align-items: center;
   padding: 16px;
   border-radius: 4px;
-  color: #ffffff;
+  color: #fff;
   text-decoration: none;
 
   .social-name {


### PR DESCRIPTION
## 概要
Issue #534 の対応として、CI (`.github/workflows/test.yml`) の `lint` ジョブに `pnpm lint:style` と `pnpm knip` を追加しました。

## 変更内容
- `.github/workflows/test.yml`: `lint` ジョブに `pnpm lint:style` および `pnpm knip` ステップを追加
- `.stylelintrc.json`: モダンな `rgb(var(...))` 表記でエラーにならないよう `color-function-notation: null` に調整
- `components/PageTitle.vue`, `pages/profile.vue`: Stylelint規約に沿うようスタイル微修正

## 完了条件の確認
- `pnpm lint`, `pnpm lint:style`, `pnpm test`, `pnpm knip` がローカルで正常に通過することを確認済み。

Closes #534