### PR TITLE
feat: 職歴ページに代表実績を追加

### DIFF
--- a/components/WorkExperience.vue
+++ b/components/WorkExperience.vue
@@ -1,0 +1,171 @@
+<template>
+  <article class="work-experience">
+    <header class="work-experience__header">
+      <p class="work-experience__period">{{ experience.period }}</p>
+      <div>
+        <h3>{{ experience.organization }}</h3>
+        <p class="work-experience__position">{{ experience.position }}</p>
+      </div>
+    </header>
+
+    <p class="work-experience__summary">{{ experience.summary }}</p>
+
+    <ul
+      v-if="experience.scale"
+      class="work-experience__scale"
+      aria-label="担当規模"
+    >
+      <li v-for="item in experience.scale" :key="item">{{ item }}</li>
+    </ul>
+
+    <div class="work-experience__highlights">
+      <section
+        v-for="highlight in experience.highlights"
+        :key="highlight.title"
+        class="experience-highlight"
+      >
+        <h4>{{ highlight.title }}</h4>
+        <p>{{ highlight.description }}</p>
+        <ul class="experience-highlight__outcomes">
+          <li v-for="outcome in highlight.outcomes" :key="outcome">
+            {{ outcome }}
+          </li>
+        </ul>
+        <ul
+          class="experience-highlight__tags"
+          :aria-label="`${highlight.title}の技術要素`"
+        >
+          <li v-for="tag in highlight.tags" :key="tag">{{ tag }}</li>
+        </ul>
+      </section>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import type { WorkExperience } from '@/constants/experiences'
+
+defineProps<{ experience: WorkExperience }>()
+</script>
+
+<style scoped>
+.work-experience {
+  padding-top: 40px;
+  border-top: 1px solid var(--color-border-strong);
+}
+
+.work-experience__header {
+  display: grid;
+  gap: 12px;
+}
+
+.work-experience__period {
+  margin: 4px 0 0;
+  color: var(--color-secondary);
+  font-family: var(--font-technical);
+  font-size: 0.8rem;
+}
+
+h3 {
+  margin: 0;
+  font-size: clamp(1.5rem, 4vw, 2rem);
+}
+
+.work-experience__position {
+  margin: 8px 0 0;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.work-experience__summary {
+  max-width: 760px;
+  margin: 24px 0 0;
+  color: var(--color-text-muted);
+  font-size: 1.05rem;
+}
+
+.work-experience__scale,
+.experience-highlight__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0;
+  list-style: none;
+}
+
+.work-experience__scale {
+  margin: 24px 0 0;
+}
+
+.work-experience__scale li {
+  padding: 8px 12px;
+  color: var(--color-text);
+  font-family: var(--font-technical);
+  font-size: 0.75rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+.work-experience__highlights {
+  display: grid;
+  gap: 16px;
+  margin-top: 40px;
+}
+
+.experience-highlight {
+  padding: 24px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.experience-highlight h4 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.experience-highlight > p {
+  margin: 12px 0 0;
+  color: var(--color-text-muted);
+}
+
+.experience-highlight__outcomes {
+  margin: 20px 0 0;
+  padding-left: 20px;
+  color: var(--color-text-muted);
+}
+
+.experience-highlight__outcomes li + li {
+  margin-top: 8px;
+}
+
+.experience-highlight__tags {
+  margin: 20px 0 0;
+}
+
+.experience-highlight__tags li {
+  padding: 3px 8px;
+  color: var(--color-secondary);
+  font-family: var(--font-technical);
+  font-size: 0.7rem;
+  background: rgb(102 217 239 / 0.08);
+  border-radius: var(--radius-full);
+}
+
+@media (width >= 720px) {
+  .work-experience__header {
+    grid-template-columns: 140px 1fr;
+  }
+
+  .work-experience__summary,
+  .work-experience__scale,
+  .work-experience__highlights {
+    margin-left: 140px;
+  }
+
+  .work-experience__highlights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+</style>

--- a/constants/experiences.ts
+++ b/constants/experiences.ts
@@ -1,0 +1,106 @@
+type ExperienceHighlight = {
+  title: string
+  description: string
+  outcomes: string[]
+  tags: string[]
+}
+
+export type WorkExperience = {
+  organization: string
+  period: string
+  position: string
+  summary: string
+  scale?: string[]
+  highlights: ExperienceHighlight[]
+}
+
+const experiences: WorkExperience[] = [
+  {
+    organization: 'メドピア株式会社',
+    period: '2019 — Present',
+    position: 'プリンシパルエンジニア / SRE / セキュリティエンジニア',
+    summary:
+      'プラットフォームSREとセキュリティ領域をリードしています。個別サービスの支援から全社共通基盤、技術ロードマップ、開発組織の仕組みづくりまで、組織を横断して取り組んでいます。',
+    scale: ['約20サービス', '40超のAWSアカウント', '4〜5名のSREチーム'],
+    highlights: [
+      {
+        title: 'AI開発基盤とガバナンス',
+        description:
+          'Claude Enterpriseの全社導入におけるセキュリティ設計と、AIエージェントを安全に活用するための実行基盤を担当しました。',
+        outcomes: [
+          'MCPの統制方針、個人情報の取り扱い、非エンジニア向けガードレールを設計',
+          '社内規約を組み込んだプラグインとMCP連携を開発し、チームへ展開',
+          'AI利用のコスト・セッション・トークンを可視化する本番基盤を構築',
+        ],
+        tags: ['Claude Code', 'MCP', 'Amazon Managed Grafana', 'ADOT'],
+      },
+      {
+        title: 'Platform SREと全社標準化',
+        description:
+          'サービスごとの運用を支援しながら、複数のプロジェクトへ再利用できる基盤と標準をコードとして整備しました。',
+        outcomes: [
+          'Terraform CloudからGitHub Actionsへの移行を主導し、コストと開発体験を改善',
+          'GitHub Actionsの権限を45リポジトリへ一斉適用',
+          '30件以上のPRを通じてBranch ProtectionからRulesetへの移行を完遂',
+        ],
+        tags: ['AWS', 'Terraform', 'GitHub Actions', 'CI/CD'],
+      },
+      {
+        title: 'セキュリティ体制とサプライチェーン防御',
+        description:
+          '個別の脆弱性対応にとどまらず、全AWSアカウントの統制と、攻撃を予防する継続的な仕組みを構築しました。',
+        outcomes: [
+          'AWS Organizations、CloudTrail、Security Hubを用いた一元的な統制を構築',
+          'セキュリティKPIと月次レビュー、中長期ロードマップを策定',
+          '依存固定、Renovate、gitleaks、zizmorなどの対策を30以上のリポジトリへ展開',
+        ],
+        tags: ['Cloud Security', 'Governance', 'Supply Chain', 'Security KPI'],
+      },
+      {
+        title: 'クラウドコストと信頼性の改善',
+        description:
+          'コストを単発で削減するのではなく、各開発チームが継続的に判断・改善できる運用へ変えることを重視しました。',
+        outcomes: [
+          'ARM化やS3ストレージクラス移行など、10〜20の削減観点を横断的に調査・提案',
+          '削減ノウハウをドキュメント化し、SRE以外も改善できる環境を整備',
+          'Cost Anomaly Detectionの全AWSアカウント導入とコスト算出の自動化を推進',
+        ],
+        tags: ['FinOps', 'AWS', 'Observability', 'Automation'],
+      },
+      {
+        title: 'アーキテクチャ設計と組織への展開',
+        description:
+          'インフラだけに閉じず、アプリケーション要件と運用を俯瞰して技術選定・設計・実装を進めています。',
+        outcomes: [
+          'AI電話の内製化に向け、LiveKitを用いたSIP・メディア分離構成を設計・構築',
+          'Terraform勉強会やゲームデーを通じ、サービスチームが自律的に運用できる体制を整備',
+          'SRE・セキュリティの中長期ロードマップを策定し、優先度と判断軸を組織へ共有',
+        ],
+        tags: ['Architecture', 'LiveKit', 'Enablement', 'Technical Strategy'],
+      },
+    ],
+  },
+  {
+    organization: '富士ゼロックス株式会社',
+    period: '2013 — 2019',
+    position: 'ソリューション開発部 / 開発リーダー・インフラチームリーダー',
+    summary:
+      'BtoB SaaSのバックエンド・フロントエンド開発とインフラを担当しました。その後、AWS移行とAWSを利用した新規サービスの立ち上げを経験し、インフラチームリーダーを務めました。',
+    highlights: [
+      {
+        title: 'アプリケーション開発からAWS基盤まで',
+        description:
+          'アプリケーションとインフラの両方に携わり、AWSへの移行、新規サービスの立ち上げへ担当領域を広げました。',
+        outcomes: [
+          'バックエンド・フロントエンドのアプリケーション開発を担当',
+          'サービスを支えるインフラを担当',
+          '既存サービスのAWS移行を実施',
+          'AWSを利用した新規サービスの立ち上げと、インフラチームのリードを担当',
+        ],
+        tags: ['AWS', 'Java', 'C#', 'JavaScript', 'Ruby on Rails'],
+      },
+    ],
+  },
+]
+
+export default experiences

--- a/pages/experience.vue
+++ b/pages/experience.vue
@@ -2,12 +2,87 @@
   <div>
     <PageTitle
       title="Experience"
-      description="学歴とこれまでの職歴を掲載しています。"
+      description="アプリケーション開発からSRE・セキュリティへ。技術を仕組みに変え、組織へ展開してきた経験を紹介します。"
     />
-    <ExperienceTimeline :items="timeline" />
+
+    <section class="career-summary" aria-labelledby="career-summary-heading">
+      <SectionHeading
+        id="career-summary-heading"
+        index="01"
+        label="Summary"
+        title="インフラから組織まで、横断して課題を解く"
+      />
+      <div class="career-summary__copy">
+        <p>
+          BtoB
+          SaaSのアプリケーション開発とリーディングを経験した後、SREへ専門領域を広げました。現在はプリンシパルエンジニアとして、プラットフォームSREとセキュリティを中心に活動しています。
+        </p>
+        <p>
+          個別の課題を解くだけでなく、コード化・標準化・教育を通じて、複数のサービスやチームが再利用できる仕組みとして残すことを重視しています。直近はAI駆動開発の基盤、ガードレール、可観測性にも取り組んでいます。
+        </p>
+      </div>
+    </section>
+
+    <section class="experience-section" aria-labelledby="work-heading">
+      <SectionHeading
+        id="work-heading"
+        index="02"
+        label="Work"
+        title="職歴と代表実績"
+        description="役割と担当範囲に加え、組織へ残した仕組みや成果をテーマ別に掲載しています。"
+      />
+      <div class="work-list">
+        <WorkExperience
+          v-for="experience in experiences"
+          :key="experience.organization"
+          :experience="experience"
+        />
+      </div>
+    </section>
+
+    <section class="experience-section" aria-labelledby="education-heading">
+      <SectionHeading
+        id="education-heading"
+        index="03"
+        label="Education"
+        title="学歴"
+      />
+      <ExperienceTimeline :items="educationTimeline" />
+    </section>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import experiences from '@/constants/experiences'
 import timeline from '@/constants/timeline'
+
+const educationTimeline = computed(() =>
+  timeline.filter((item) => item.color !== 'warning')
+)
 </script>
+
+<style scoped>
+.career-summary__copy {
+  max-width: 760px;
+  color: var(--color-text-muted);
+  font-size: 1.05rem;
+}
+
+.career-summary__copy p {
+  margin: 0;
+}
+
+.career-summary__copy p + p {
+  margin-top: 16px;
+}
+
+.experience-section {
+  padding-top: 96px;
+}
+
+.work-list {
+  display: grid;
+  gap: 80px;
+}
+</style>

--- a/test/e2e/content.spec.ts
+++ b/test/e2e/content.spec.ts
@@ -12,10 +12,12 @@ test('home shows its primary information without scrolling', async ({
   await expect(page.locator('#experience .timeline li')).toHaveCount(2)
 })
 
-test('experience shows the complete timeline', async ({ page }) => {
+test('experience shows work highlights and education', async ({ page }) => {
   await page.goto('/experience')
 
-  await expect(page.locator('.timeline li')).toHaveCount(6)
+  await expect(page.locator('.work-experience')).toHaveCount(2)
+  await expect(page.locator('.experience-highlight')).toHaveCount(6)
+  await expect(page.locator('.timeline li')).toHaveCount(4)
 })
 
 test('profile keeps personal details and external profiles', async ({


### PR DESCRIPTION
## 概要

LAPRASの職務経歴をもとに、Experienceページを略歴中心の年表から、職歴と代表実績を詳しく読める構成へ更新しました。

## 変更内容

- Career summary、職歴と代表実績、学歴の3セクションへ再構成
- メドピアでの取り組みを5テーマ、富士ゼロックスでの経験を1テーマに編集
- 担当規模、成果、技術タグを表示する `WorkExperience` コンポーネントを追加
- Homeで使っている短い職歴タイムラインは変更せず、Experienceページでは学歴のみタイムライン表示
- E2Eテストを新しい情報構造に合わせて更新

## キャプチャ

### Desktop

![Experience page - desktop](https://github.com/reireias/reireias.github.io/releases/download/untagged-26ecd68a22f46dd37046/experience-desktop.png)

### Mobile

![Experience page - mobile](https://github.com/reireias/reireias.github.io/releases/download/untagged-26ecd68a22f46dd37046/experience-mobile.png)

## 確認内容

- `pnpm lint`
- `pnpm lint:style`
- `pnpm test -- --runInBand`
- `pnpm generate`
- `pnpm test:e2e`（13 tests passed）
- デスクトップ・モバイルのキャプチャで表示確認