### PR TITLE
chore: PRマージ後のmaster同期を明記

### DIFF
--- a/.agents/rules/20-git-workflow.md
+++ b/.agents/rules/20-git-workflow.md
@@ -11,6 +11,7 @@
 - 新機能や修正ではトピックブランチを作成し、Pull Requestを経由する。
 - CIが成功しても、ユーザーの明示的な承認なしにPull Requestをマージしない。
 - マージを依頼された場合は、squashやrebaseではなく `env gh pr merge <番号> --merge` でマージコミットを作る。
+- Pull Requestをマージした後は、`git switch master` と `git pull --ff-only origin master` を実行し、ローカルの `master` を最新化する。最後にローカル変更がなく、`master` と `origin/master` が同期していることを確認する。
 
 ## コミット
 

--- a/.agents/workflows/merge.md
+++ b/.agents/workflows/merge.md
@@ -9,6 +9,7 @@ turbo: true
 
 1. `env gh pr view --json number -q .number` で現在のブランチのPR番号を取得する。
 2. `env gh pr merge <番号> --merge` でマージする。必ずマージコミット方式を使う。
-3. `git switch master` と `git pull` でmasterを最新化する。
+3. `git switch master` と `git pull --ff-only origin master` でローカルのmasterを最新化する。
+4. `git status --short --branch` などで、ローカル変更がなく、masterとorigin/masterが同期していることを確認する。
 
 // turbo

--- a/.rulesync/commands/merge.md
+++ b/.rulesync/commands/merge.md
@@ -10,4 +10,5 @@ antigravity:
 
 1. `env gh pr view --json number -q .number` で現在のブランチのPR番号を取得する。
 2. `env gh pr merge <番号> --merge` でマージする。必ずマージコミット方式を使う。
-3. `git switch master` と `git pull` でmasterを最新化する。
+3. `git switch master` と `git pull --ff-only origin master` でローカルのmasterを最新化する。
+4. `git status --short --branch` などで、ローカル変更がなく、masterとorigin/masterが同期していることを確認する。

--- a/.rulesync/rules/20-git-workflow.md
+++ b/.rulesync/rules/20-git-workflow.md
@@ -21,6 +21,7 @@ antigravity:
 - 新機能や修正ではトピックブランチを作成し、Pull Requestを経由する。
 - CIが成功しても、ユーザーの明示的な承認なしにPull Requestをマージしない。
 - マージを依頼された場合は、squashやrebaseではなく `env gh pr merge <番号> --merge` でマージコミットを作る。
+- Pull Requestをマージした後は、`git switch master` と `git pull --ff-only origin master` を実行し、ローカルの `master` を最新化する。最後にローカル変更がなく、`master` と `origin/master` が同期していることを確認する。
 
 ## コミット
 


### PR DESCRIPTION
## 概要

PRをマージした後、ローカルのmasterも必ず最新化する手順をGitワークフロー規約へ明記しました。

## 変更内容

- マージ後に `git switch master` を実行
- `git pull --ff-only origin master` で安全に最新化
- ローカル変更がなく、`master` と `origin/master` が同期していることを確認
- `/merge` ワークフローにも同じ手順を反映
- Rulesyncで生成物を更新

## 確認内容

- `pnpm ai:generate`
- `pnpm ai:check`
- pre-commit hook（knip）