### PR TITLE
fix: Heroを通常スクロールへ変更

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -358,24 +358,25 @@ Motionは、状態変化、空間的な関係、サイトの個性を伝える�
 
 ### Home Scroll-linked Animation
 
-Homeは、通常のスクロールに連動するシグネチャーアニメーションを使用する。スクロール操作を奪うscroll-jackingは行わない。
+Homeは、通常のスクロールに連動するシグネチャーアニメーションを使用する。Heroは固定せず、スクロール操作と同時にAboutが画面内へ入り始める構造とする。
 
-Heroを一時的にsticky表示し、scroll progressを0〜100%として次のsequenceを表現する。
+アバター、名前、肩書き、紹介文は最初から完成状態で表示し、背景のTopologyのみをscroll progress 0〜100%として変化させる。
 
 | Progress | State |
 | --- | --- |
-| `0–25%` | 薄いtechnical gridとcyanのcursorまたは`>`を表示する |
-| `25–50%` | Monokai greenのcellが中心または左上から組み上がる |
-| `50–75%` | cellが収束し、iconまたは`reireias.dev`のsymbolを形成する |
-| `75–100%` | symbolを移動し、名前、肩書き、紹介文を表示してAboutへつなぐ |
+| `0–25%` | 薄いtechnical gridと疎らなcyanのnodeを表示する |
+| `25–70%` | node間の経路が段階的に接続され、Topologyが明るくなる |
+| `70–100%` | 接続状態を保ったままTopologyを弱め、Aboutへつなぐ |
 
 実装時は次を必須とする。
 
-- desktopの演出区間は`180–220vh`を目安とする。
-- mobileは`130–160vh`へ短縮し、cell数と移動量を減らす。
+- Heroはheaderを除く1画面以内とし、追加のスクロール領域を設けない。
+- 背景アニメーションの進行範囲はdesktopで`75svh`、mobileで`65svh`を目安とする。
+- mobileはTopologyを中央部分へ絞り、node数と経路の情報量を減らす。
+- 前景コンテンツの背面には保護領域を設け、Topologyとのコントラストを一定に保つ。
 - wheel、touch、keyboardによる通常のスクロール位置や速度を変更しない。
 - Hero演出にscroll snapを使用しない。
-- animation完了前でも主要情報へアクセスできる構造にする。
+- animationの進行にかかわらず主要情報へアクセスできる構造にする。
 - JavaScriptが無効または失敗した場合は、最終状態の内容を表示する。
 - Core Web Vitalsへ影響する大きな画像やlayout shiftを発生させない。
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -554,22 +554,13 @@ h1 {
 }
 
 @supports (animation-timeline: scroll()) {
-  .hero {
-    height: 135svh;
-  }
-
-  .hero__sticky {
-    position: sticky;
-    top: 64px;
-  }
-
   .hero__topology-links path {
     animation-name: connect-topology;
     animation-duration: 1ms;
     animation-timing-function: linear;
     animation-fill-mode: both;
     animation-timeline: scroll(root block);
-    animation-range: 0 35svh;
+    animation-range: 0 65svh;
   }
 
   .hero__topology-links path:nth-child(2),
@@ -583,7 +574,7 @@ h1 {
     animation-timing-function: linear;
     animation-fill-mode: both;
     animation-timeline: scroll(root block);
-    animation-range: 0 35svh;
+    animation-range: 0 65svh;
   }
 
   .hero__scroll {
@@ -664,17 +655,9 @@ h1 {
   }
 
   @supports (animation-timeline: scroll()) {
-    .hero {
-      height: 180svh;
-    }
-
-    .hero__sticky {
-      top: 72px;
-    }
-
     .hero__topology-links path,
     .hero__topology-nodes circle {
-      animation-range: 0 80svh;
+      animation-range: 0 75svh;
     }
 
     .hero__scroll {
@@ -684,15 +667,6 @@ h1 {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hero {
-    height: auto;
-  }
-
-  .hero__sticky {
-    position: relative;
-    top: auto;
-  }
-
   .hero__topology-links path,
   .hero__topology-nodes circle,
   .hero__copy,

--- a/test/e2e/content.spec.ts
+++ b/test/e2e/content.spec.ts
@@ -12,7 +12,7 @@ test('home shows its primary information without scrolling', async ({
   await expect(page.locator('#experience .timeline li')).toHaveCount(2)
 })
 
-test('home connects topology nodes in both scroll directions while keeping the hero content fixed', async ({
+test('home connects topology nodes in both directions while scrolling the hero naturally', async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 800 })
@@ -29,10 +29,10 @@ test('home connects topology nodes in both scroll directions while keeping the h
     await topologyPath.evaluate((element) => getComputedStyle(element).opacity)
   )
 
-  await expect(hero).toHaveCSS('height', '1440px')
+  await expect(hero).toHaveCSS('height', '728px')
   await expect(topologyPath).toHaveCSS('stroke-dashoffset', '1px')
 
-  await page.evaluate(() => window.scrollTo(0, 400))
+  await page.evaluate(() => window.scrollTo(0, 240))
   await page.waitForTimeout(100)
 
   const activeContentBox = await content.boundingBox()
@@ -40,9 +40,10 @@ test('home connects topology nodes in both scroll directions while keeping the h
     await topologyPath.evaluate((element) => getComputedStyle(element).opacity)
   )
 
-  expect(
-    Math.abs((activeContentBox?.y ?? 0) - (initialContentBox?.y ?? 0))
-  ).toBeLessThanOrEqual(2)
+  expect((activeContentBox?.y ?? 0) - (initialContentBox?.y ?? 0)).toBeCloseTo(
+    -240,
+    0
+  )
   expect(activePathOpacity).toBeGreaterThan(initialPathOpacity + 0.2)
   await expect(page.locator('.hero__identity img')).toBeVisible()
   await expect(page.getByRole('heading', { name: 'reireias' })).toBeVisible()
@@ -75,9 +76,7 @@ test('home connects topology nodes in both scroll directions while keeping the h
       )
     )
     .toBeCloseTo(initialPathOpacity, 2)
-  expect(
-    Math.abs((returnedContentBox?.y ?? 0) - (initialContentBox?.y ?? 0))
-  ).toBeLessThanOrEqual(2)
+  expect(returnedContentBox?.y).toBeCloseTo(initialContentBox?.y ?? 0, 0)
 })
 
 test('home keeps the mobile hero sequence compact', async ({ page }) => {
@@ -87,9 +86,10 @@ test('home keeps the mobile hero sequence compact', async ({ page }) => {
   const heroHeight = await page
     .locator('.hero')
     .evaluate((element) => element.getBoundingClientRect().height)
+  const initialContentBox = await page.locator('.hero__content').boundingBox()
 
-  expect(heroHeight).toBeCloseTo(844 * 1.35, 0)
-  expect(heroHeight).toBeLessThan(844 * 1.5)
+  expect(heroHeight).toBeCloseTo(844 - 64, 0)
+  expect(heroHeight).toBeLessThan(844)
 
   await page.evaluate(() => window.scrollTo(0, 295))
   await page.waitForTimeout(300)
@@ -104,6 +104,7 @@ test('home keeps the mobile hero sequence compact', async ({ page }) => {
   expect(viewportMetrics.scrollWidth).toBe(viewportMetrics.innerWidth)
   expect(viewportMetrics.scrollX).toBe(0)
   expect(contentBox?.x).toBeGreaterThanOrEqual(16)
+  expect(contentBox?.y).toBeLessThan((initialContentBox?.y ?? 0) - 250)
 })
 
 test('home shows the settled topology without a sticky sequence for reduced motion', async ({


### PR DESCRIPTION
## 概要

PR #575で追加したTopology背景アニメーションからsticky表示を外し、スクロール操作と同時にHeroが移動するよう変更します。

背景アニメーションは維持しつつ、Hero内でスクロールが消費される感覚をなくし、Aboutがすぐ画面内へ入り始めるようにしました。

## 変更内容

- Heroの`135svh` / `180svh`の追加高さを削除
- `.hero__sticky`の`position: sticky`を削除
- Topologyの進行範囲をモバイル65svh、デスクトップ75svhに調整
- E2Eを前景固定の確認から、スクロール量に応じてHeroが移動する確認へ変更
- モバイルHeroがヘッダーを除く1画面以内であることを検証
- 開始・途中・終了・逆スクロールのTopology状態検証は維持
- `docs/design.md`のMotion仕様を通常スクロールとTopologyの設計へ更新

## キャプチャ

スクロール途中の状態です。Heroが上へ移動し、同じ画面内にAboutが入り始めます。

| Desktop | Mobile |
| --- | --- |
| ![Natural scroll desktop](https://github.com/reireias/reireias.github.io/releases/download/untagged-9f1e755e83660c945bf9/natural-scroll-desktop.png) | ![Natural scroll mobile](https://github.com/reireias/reireias.github.io/releases/download/untagged-9f1e755e83660c945bf9/natural-scroll-mobile.png) |

## 検証

- `pnpm lint`
- `pnpm lint:style`
- `pnpm test`（7 tests passed）
- `pnpm generate`
- `pnpm test:e2e`（16 tests passed）
- Chromiumでデスクトップ・モバイルのスクロール途中を目視確認
