### PR TITLE
feat: パフォーマンス監査のCIゲートを安定化

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Run Unlighthouse performance audit
         run: pnpm audit:performance
+      - name: Upload Unlighthouse report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: unlighthouse-report
+          path: .unlighthouse/
+          include-hidden-files: true
+          retention-days: 30
       - name: Run Playwright E2E tests
         run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm test:e2e
       - name: Upload Playwright report

--- a/docs/performance-audit.md
+++ b/docs/performance-audit.md
@@ -1,0 +1,46 @@
+# Performance audit
+
+## Purpose
+
+Performance audits detect regressions in pull requests. The final Lighthouse 95+
+target in Issue #561 is verified against the deployed production site separately;
+the local CI audit is a stable baseline for comparing code changes.
+
+## Local CI audit
+
+Run the same audit used by GitHub Actions:
+
+```bash
+pnpm audit:performance
+```
+
+The command generates the static site, serves `dist` without compression or cache,
+and audits every configured route with mobile throttling. Each route is measured
+three times, and Unlighthouse selects the median Lighthouse run. The result table
+includes Performance, FCP, LCP, TBT, and CLS.
+
+The regression budgets are deliberately separated by route type:
+
+- Main public routes: Performance 60+
+- `/sandbox/**`: Performance 55+
+- All routes: Accessibility, Best Practices, and SEO 100
+
+Sandbox pages contain experimental code and are not part of the final 95+ target,
+but the lower budget still prevents major regressions. The budgets should be raised
+in small steps after improvements consistently pass multiple CI runs.
+
+GitHub Actions uploads `.unlighthouse/` as the `unlighthouse-report` artifact and
+adds the page-by-page table to the job summary.
+
+## Local and production roles
+
+The local server intentionally disables caching and compression. This makes pull
+request comparisons repeatable, but produces lower Performance scores than the
+deployed site. Production uses GitHub Pages and Cloudflare delivery, including gzip
+or Brotli compression and browser caching, so local and production scores must not
+be compared as if their delivery conditions were identical.
+
+After deployment, audit the main public routes multiple times under the same mobile
+settings and use the median result. Confirm response compression and cache headers
+at the same time. Record the production scores and Core Web Vitals-like metrics in
+Issue #561; do not use a single run as the completion result.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:style": "stylelint \"**/*.{css,scss,vue}\" --ignore-path .gitignore",
     "lint:style:fix": "stylelint \"**/*.{css,scss,vue}\" --ignore-path .gitignore --fix",
     "generate": "nuxi generate && rm -rf dist && cp -r .output/public dist && echo 'reireias.dev' > dist/CNAME",
-    "audit:performance": "pnpm generate && start-server-and-test 'http-server ./dist -p 3000 -c-1 -s' http://127.0.0.1:3000 'unlighthouse-ci --site http://127.0.0.1:3000'",
+    "audit:performance": "pnpm generate && start-server-and-test 'http-server ./dist -p 3000 -c-1 -s' http://127.0.0.1:3000 'unlighthouse-ci --site http://127.0.0.1:3000 && node scripts/verify-performance-audit.mjs'",
     "benchmark": "node scripts/benchmark.js https://reireias.github.io $(git rev-parse HEAD)",
     "test": "jest",
     "test:e2e": "playwright test",

--- a/scripts/verify-performance-audit.mjs
+++ b/scripts/verify-performance-audit.mjs
@@ -1,0 +1,87 @@
+import { appendFile, readFile } from 'node:fs/promises'
+import process from 'node:process'
+
+const REPORT_ROOT = '.unlighthouse/reports'
+const PUBLIC_PERFORMANCE_BUDGET = 60
+const SANDBOX_PERFORMANCE_BUDGET = 55
+
+const formatMetric = (audit, divisor = 1, suffix = '') => {
+  if (typeof audit?.numericValue !== 'number') return 'n/a'
+
+  return `${Math.round((audit.numericValue / divisor) * 100) / 100}${suffix}`
+}
+
+const getReportPath = (routePath) => {
+  const relativePath = routePath === '/' ? '' : routePath.replace(/^\//, '')
+  return `${REPORT_ROOT}/${relativePath}lighthouse.json`
+}
+
+const getBudget = (routePath) =>
+  routePath.startsWith('/sandbox/') || routePath === '/sandbox/'
+    ? SANDBOX_PERFORMANCE_BUDGET
+    : PUBLIC_PERFORMANCE_BUDGET
+
+const simpleReports = JSON.parse(
+  await readFile('.unlighthouse/ci-result.json', 'utf8')
+)
+
+if (!Array.isArray(simpleReports) || simpleReports.length === 0) {
+  throw new Error('Unlighthouse did not produce any route results')
+}
+
+const rows = await Promise.all(
+  simpleReports.map(async (simpleReport) => {
+    if (
+      typeof simpleReport.path !== 'string' ||
+      !Number.isFinite(simpleReport.performance)
+    ) {
+      throw new Error('Unlighthouse produced an invalid route result')
+    }
+
+    const report = JSON.parse(
+      await readFile(getReportPath(simpleReport.path), 'utf8')
+    )
+    const budget = getBudget(simpleReport.path)
+
+    return {
+      path: simpleReport.path,
+      performance: simpleReport.performance * 100,
+      budget,
+      fcp: formatMetric(report.audits['first-contentful-paint'], 1000, 's'),
+      lcp: formatMetric(report.audits['largest-contentful-paint'], 1000, 's'),
+      tbt: formatMetric(report.audits['total-blocking-time'], 1, 'ms'),
+      cls: formatMetric(report.audits['cumulative-layout-shift']),
+    }
+  })
+)
+
+const markdown = [
+  '## Unlighthouse performance audit',
+  '',
+  'Scores and metrics use the median Lighthouse run from three mobile samples.',
+  '',
+  '| Route | Performance | Budget | FCP | LCP | TBT | CLS |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
+  ...rows.map(
+    ({ path, performance, budget, fcp, lcp, tbt, cls }) =>
+      `| \`${path}\` | ${Math.round(performance)} | ${budget} | ${fcp} | ${lcp} | ${tbt} | ${cls} |`
+  ),
+  '',
+].join('\n')
+
+console.log(markdown)
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown)
+}
+
+const failures = rows.filter(({ performance, budget }) => performance < budget)
+
+if (failures.length > 0) {
+  const details = failures
+    .map(
+      ({ path, performance, budget }) => `${path}: ${performance} < ${budget}`
+    )
+    .join(', ')
+  throw new Error(`Performance budget failed: ${details}`)
+}

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -16,7 +16,8 @@ export default defineUnlighthouseConfig({
   ],
   scanner: {
     device: 'mobile',
-    samples: 1,
+    // Unlighthouse selects Lighthouse's median run when multiple samples exist.
+    samples: 3,
     throttle: true,
   },
   chrome: {


### PR DESCRIPTION
## 概要

#561 Phase 1の残作業として、Unlighthouse監査を複数回計測の中央値で判定し、主要公開ページとsandboxのリグレッション基準を分離します。

Refs #561

## 変更内容

- 各ルートのLighthouse計測を3回に増やし、Unlighthouseの中央値ランを採用
- 主要公開ページをPerformance 60以上、`/sandbox/**`を55以上として個別に検証
- ページ別のPerformance / FCP / LCP / TBT / CLSをコンソールとGitHub Actions Job Summaryへ出力
- `.unlighthouse/`レポートを30日間のCI artifactとして保存
- ローカル監査と本番監査の役割、圧縮・キャッシュ条件の差、段階的な閾値引き上げ方針を文書化

## 検証

- [x] `pnpm ai:check`
- [x] `pnpm lint`
- [x] `pnpm lint:style`
- [x] `pnpm knip`
- [x] `pnpm test --runInBand`
- [x] `pnpm audit:performance`
- [x] `pnpm test:e2e`
- [x] `pnpm nuxi prepare`
- [x] `dist/index.html`、`dist/_nuxt/`、`dist/CNAME`を確認

3サンプル中央値で、主要公開ページはPerformance 61〜65、sandboxは62〜63でした。全ページでTBT 0ms、CLS 0を維持しています。

## 補足

静的生成時に既存の`definePageMeta`警告が2件出ます。#561 Phase 4の対応項目であり、本PRによる新規警告ではありません。
