### PR TITLE
feat: ページ固有のSEO情報とsitemapを追加

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -3,3 +3,70 @@
     <NuxtPage />
   </NuxtLayout>
 </template>
+
+<script setup lang="ts">
+import { useHead, useRoute, useSeoMeta } from '#imports'
+import { computed } from 'vue'
+import { getCanonicalUrl, getPageSeo, siteUrl } from '@/constants/seo'
+
+const route = useRoute()
+const seo = computed(() => getPageSeo(route.path))
+const canonicalUrl = computed(() => getCanonicalUrl(route.path))
+
+useSeoMeta({
+  title: () => seo.value.title,
+  description: () => seo.value.description,
+  robots: () => seo.value.robots ?? 'index, follow',
+  ogTitle: () => seo.value.title,
+  ogDescription: () => seo.value.description,
+  ogUrl: () => canonicalUrl.value,
+  twitterTitle: () => seo.value.title,
+  twitterDescription: () => seo.value.description,
+})
+
+useHead(() => ({
+  link: [{ rel: 'canonical', href: canonicalUrl.value }],
+  script:
+    route.path === '/'
+      ? [
+          {
+            type: 'application/ld+json',
+            innerHTML: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@graph': [
+                {
+                  '@type': 'WebSite',
+                  '@id': `${siteUrl}/#website`,
+                  url: siteUrl,
+                  name: 'reireias.dev',
+                  inLanguage: 'ja',
+                },
+                {
+                  '@type': 'ProfilePage',
+                  '@id': `${siteUrl}/#profile-page`,
+                  url: siteUrl,
+                  name: seo.value.title,
+                  isPartOf: { '@id': `${siteUrl}/#website` },
+                  mainEntity: { '@id': `${siteUrl}/#person` },
+                },
+                {
+                  '@type': 'Person',
+                  '@id': `${siteUrl}/#person`,
+                  name: 'reireias',
+                  url: siteUrl,
+                  image: `${siteUrl}/icon.png`,
+                  jobTitle: 'Principal Engineer',
+                  knowsAbout: [
+                    'Site Reliability Engineering',
+                    'Security Engineering',
+                    'AI Engineering',
+                    'Software Architecture',
+                  ],
+                },
+              ],
+            }),
+          },
+        ]
+      : [],
+}))
+</script>

--- a/constants/seo.ts
+++ b/constants/seo.ts
@@ -1,0 +1,79 @@
+export const siteUrl = 'https://reireias.dev'
+
+export interface PageSeo {
+  title: string
+  description: string
+  canonicalPath?: string
+  robots?: 'index, follow' | 'noindex, follow'
+}
+
+const defaultSeo: PageSeo = {
+  title: 'reireias | Principal Engineer / SRE & Security',
+  description:
+    'SREとセキュリティを専門とするプリンシパルエンジニア、reireiasのポートフォリオです。',
+}
+
+const pageSeo: Record<string, PageSeo> = {
+  '/': defaultSeo,
+  '/articles': {
+    title: 'Articles & Talks | reireias',
+    description: 'reireiasが執筆した記事、登壇資料、個人の制作物を紹介します。',
+  },
+  '/experience': {
+    title: 'Experience | reireias',
+    description:
+      'アプリケーション開発からSRE・セキュリティまで、reireiasの職歴と代表実績を紹介します。',
+  },
+  '/job': {
+    title: 'Experienceへの移行案内 | reireias',
+    description: '職歴ページはExperienceへ移動しました。',
+    canonicalPath: '/experience',
+    robots: 'noindex, follow',
+  },
+  '/profile': {
+    title: 'Profile | reireias',
+    description:
+      'プリンシパルエンジニアとしての現在の仕事と、reireiasの個人プロフィールを紹介します。',
+  },
+  '/skill': {
+    title: 'Skillsへの移行案内 | reireias',
+    description: 'スキルページはSkillsへ移動しました。',
+    canonicalPath: '/skills',
+    robots: 'noindex, follow',
+  },
+  '/skills': {
+    title: 'Skills | reireias',
+    description:
+      'SRE、セキュリティ、AI、アーキテクチャを中心としたreireiasの専門領域と技術スタックを紹介します。',
+  },
+  '/sandbox': {
+    title: 'Sandbox | reireias',
+    description: 'UIやアニメーションの技術検証を掲載しています。',
+    robots: 'noindex, follow',
+  },
+  '/sandbox/anime': {
+    title: 'Anime Experiments | reireias',
+    description: 'anime.jsを使ったアニメーションの技術検証ページです。',
+    robots: 'noindex, follow',
+  },
+  '/template': {
+    title: 'Template | reireias',
+    description: 'UIコンポーネントのテンプレートページです。',
+    robots: 'noindex, follow',
+  },
+}
+
+const normalizePath = (path: string): string =>
+  path === '/' ? path : path.replace(/\/+$/, '')
+
+export const getPageSeo = (path: string): PageSeo =>
+  pageSeo[normalizePath(path)] ?? {
+    ...defaultSeo,
+    robots: 'noindex, follow',
+  }
+
+export const getCanonicalUrl = (path: string): string => {
+  const normalizedPath = normalizePath(path)
+  const seo = getPageSeo(normalizedPath)
+  return `${siteUrl}${seo.canonicalPath ?? normalizedPath}`
+}

--- a/docs/performance-audit.md
+++ b/docs/performance-audit.md
@@ -17,17 +17,22 @@ pnpm audit:performance
 The command generates the static site, serves `dist` without compression or cache,
 and audits every configured route with mobile throttling. Each route is measured
 three times, and Unlighthouse selects the median Lighthouse run. The result table
-includes Performance, FCP, LCP, TBT, and CLS.
+includes Performance, SEO, FCP, LCP, TBT, and CLS.
 
 The regression budgets are deliberately separated by route type:
 
 - Main public routes: Performance 60+
 - `/sandbox/**`: Performance 55+
-- All routes: Accessibility, Best Practices, and SEO 100
+- All routes: Accessibility and Best Practices 100
+- Indexable routes (`/`, `/articles/`, `/experience/`, `/profile/`, `/skills/`):
+  SEO 100
 
 Sandbox pages contain experimental code and are not part of the final 95+ target,
-but the lower budget still prevents major regressions. The budgets should be raised
-in small steps after improvements consistently pass multiple CI runs.
+and migration, sandbox, and template pages are intentionally marked `noindex`.
+Lighthouse lowers the SEO score for `noindex`, so those routes are excluded only
+from the SEO score gate; their other category and performance budgets still prevent
+major regressions. The budgets should be raised in small steps after improvements
+consistently pass multiple CI runs.
 
 GitHub Actions uploads `.unlighthouse/` as the `unlighthouse-report` artifact and
 adds the page-by-page table to the job summary.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,3 @@
-import pkg from './package.json'
-
 export default defineNuxtConfig({
   ssr: true,
   telemetry: false,
@@ -12,24 +10,11 @@ export default defineNuxtConfig({
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        { name: 'description', content: pkg.description },
         {
           property: 'og:site_name',
           content: 'reireias portfolio',
         },
         { property: 'og:type', content: 'website' },
-        {
-          property: 'og:url',
-          content: 'https://reireias.dev',
-        },
-        {
-          property: 'og:title',
-          content: 'reireias portfolio',
-        },
-        {
-          property: 'og:description',
-          content: pkg.description,
-        },
         {
           property: 'og:image',
           content: 'https://reireias.dev/ogp.png',
@@ -41,14 +26,6 @@ export default defineNuxtConfig({
         {
           name: 'twitter:site',
           content: '@reirei_As',
-        },
-        {
-          name: 'twitter:title',
-          content: 'reireias.dev',
-        },
-        {
-          name: 'twitter:description',
-          content: pkg.description,
         },
         {
           name: 'twitter:image',
@@ -65,7 +42,20 @@ export default defineNuxtConfig({
     },
   },
   css: ['@/assets/app.css'],
-  modules: ['@nuxt/image', '@nuxt/ui'],
+  modules: ['@nuxt/image', '@nuxt/ui', '@nuxtjs/sitemap'],
+  site: {
+    url: 'https://reireias.dev',
+    name: 'reireias.dev',
+  },
+  sitemap: {
+    zeroRuntime: true,
+  },
+  routeRules: {
+    '/job': { sitemap: false },
+    '/skill': { sitemap: false },
+    '/template': { sitemap: false },
+    '/sandbox/**': { sitemap: false },
+  },
   colorMode: {
     preference: 'dark',
     fallback: 'dark',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@eslint/js": "^9.39.5",
     "@nuxt/image": "^2.1.0",
     "@nuxt/ui": "^4.10.0",
+    "@nuxtjs/sitemap": "^8.3.3",
     "@playwright/test": "^1.62.1",
     "@types/animejs": "^3.1.13",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@nuxt/ui':
         specifier: ^4.10.0
         version: 4.10.0(4427c2322f18cae846ae6b149d5fa45a)
+      '@nuxtjs/sitemap':
+        specifier: ^8.3.3
+        version: 8.3.3(6c7f801564248cdff849331bae72742d)
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
@@ -1752,6 +1755,11 @@ packages:
     peerDependencies:
       vite: '>=6.0'
 
+  '@nuxt/devtools-kit@4.0.0-alpha.7':
+    resolution: {integrity: sha512-Tgh+tSejh1GnZjdjgWyc4qCxskeX08XuSQBYMn/4SIV5AubeqYeAOMBD2qSmHOXjMCUpgyzpEhODcP3sgdgGRA==}
+    peerDependencies:
+      vite: '>=6.0'
+
   '@nuxt/devtools-wizard@3.4.1':
     resolution: {integrity: sha512-taGeuTnkHsZVjgD9r6NXvvHaBzB2j4mCgOmlmkz3ntsqgh1SJfmsD11Tmtl7FVAxJS8Wuvuzgt0GyTlADBW9Wg==}
     hasBin: true
@@ -1888,6 +1896,15 @@ packages:
 
   '@nuxtjs/color-mode@4.0.1':
     resolution: {integrity: sha512-eiA7hWXi5zNHaYKyJFCGF6i0wFZtuvR7KDXZ6jiSvwxjCpRFwphrw0MOSmNfArTSSsT1wpW+/2H92cejeVfUlg==}
+
+  '@nuxtjs/sitemap@8.3.3':
+    resolution: {integrity: sha512-voYdRe4n4TDQ17aRXBbpAszSD8O2AEM9759piG3PHBmBG6Jtc2nEH7zUClCjeSLjKmAkaeDhLMxSzrZBMjuAfw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: '>=3'
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -6772,6 +6789,14 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nuxt-site-config-kit@4.2.0:
+    resolution: {integrity: sha512-5vcDTXMwvFquFf8jesB2CuZOEZtOx7ZrP9RqqF9ZvZgMyCWVYLDSDdbE+/onTXb42AjfaYTb+gwHF3sZ2ZLuGw==}
+
+  nuxt-site-config@4.2.0:
+    resolution: {integrity: sha512-Vyb8/ylP1KYuH/IlMTaY0PQgQfqEQZYAi8AQXq0ymTTboexMlLIrF1s17BFIx8jbtI5rrKWCa5xPbHGNtJ34FQ==}
+    peerDependencies:
+      vue: ^3.5.30
+
   nuxt@4.5.2:
     resolution: {integrity: sha512-tR3fcqeHlHmmkLMpIg3V7Y+1ltr302lW8djMw/iy+myfo7QSSz+BVJDuQhg5j73b9oteSyBfOKTDYTgvMtj6TA==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
@@ -6784,6 +6809,20 @@ packages:
       '@parcel/watcher':
         optional: true
       '@types/node':
+        optional: true
+
+  nuxtseo-shared@5.3.10:
+    resolution: {integrity: sha512-6TduAGz7Kx2ytOpHU6DMXr5voAolq4104D7KZ9EK6I5ABCV+PDrIxB1xeu8OLLYpD/Yf+REFvM+HIIVCqSRCoQ==}
+    peerDependencies:
+      '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt-site-config: ^3.2.0 || ^4.0.0
+      vue: ^3.5.0
+      zod: ^3.23.0 || ^4.0.0
+    peerDependenciesMeta:
+      nuxt-site-config:
+        optional: true
+      zod:
         optional: true
 
   nwsapi@2.2.24:
@@ -7882,6 +7921,15 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  site-config-stack@4.2.0:
+    resolution: {integrity: sha512-clV6zAwnsl/xQJCYE+Z/QHciPZ5DP5B3L0s7plOJ92ro8kIe6D/UZlX8JGZC1E18CUeyeJTKBcFWNIRZxSdUJw==}
+    peerDependencies:
+      vue: ^3.5.30
+
+  sitemapd@0.2.1:
+    resolution: {integrity: sha512-ei/QCl/cxTPEC8b/KtibUalvORO4q1ZIN8h22gq6DaSUuHO9jolYViHSojEDPll/AmH4CQnFDkKNuiyMOs83ig==}
+    engines: {node: '>=18.0.0'}
 
   sitemapper@4.1.6:
     resolution: {integrity: sha512-EI2dvLWzPw7+FI6LQPjdo6P4IZ4HFv0vNmssE3Hloqq/sVO9URGMPmrcP4PCNgydCBGIETAZnVmW86h8vwbHrA==}
@@ -10992,6 +11040,18 @@ snapshots:
       - rolldown
       - unplugin
 
+  '@nuxt/devtools-kit@4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
+      tinyexec: 1.3.0
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
   '@nuxt/devtools-wizard@3.4.1':
     dependencies:
       '@clack/prompts': 1.7.0
@@ -11527,6 +11587,33 @@ snapshots:
       - oxc-parser
       - rolldown
       - unplugin
+
+  '@nuxtjs/sitemap@8.3.3(6c7f801564248cdff849331bae72742d)':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt-site-config: 4.2.0(6c7f801564248cdff849331bae72742d)
+      nuxtseo-shared: 5.3.10(48eb8ff535cb0811f0d4c922704658fa)
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sitemapd: 0.2.1
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
+    optionalDependencies:
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@nuxt/schema'
+      - magic-string
+      - magicast
+      - nuxt
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - vue
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -17159,6 +17246,45 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nuxt-site-config-kit@4.2.0(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3)):
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
+      site-config-stack: 4.2.0(vue@3.5.41(typescript@5.9.3))
+      std-env: 4.2.0
+      ufo: 1.6.4
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vue
+
+  nuxt-site-config@4.2.0(6c7f801564248cdff849331bae72742d):
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
+      consola: 3.4.2
+      defu: 6.1.7
+      h3: 1.15.11
+      nuxt-site-config-kit: 4.2.0(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3))
+      nuxtseo-shared: 5.3.10(48eb8ff535cb0811f0d4c922704658fa)
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      site-config-stack: 4.2.0(vue@3.5.41(typescript@5.9.3))
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@nuxt/schema'
+      - magic-string
+      - magicast
+      - nuxt
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - zod
+
   nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(commander@15.0.0)(db0@0.3.4)(esbuild@0.28.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@5.9.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.1)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
@@ -17300,6 +17426,36 @@ snapshots:
       - webpack
       - xml2js
       - yaml
+
+  nuxtseo-shared@5.3.10(48eb8ff535cb0811f0d4c922704658fa):
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
+      '@nuxt/schema': 4.5.2
+      birpc: 4.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(commander@15.0.0)(db0@0.3.4)(esbuild@0.28.1)(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@5.9.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nypm: 0.6.9
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.2.0
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@5.9.3)
+    optionalDependencies:
+      nuxt-site-config: 4.2.0(6c7f801564248cdff849331bae72742d)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
 
   nwsapi@2.2.24: {}
 
@@ -18607,6 +18763,15 @@ snapshots:
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}
+
+  site-config-stack@4.2.0(vue@3.5.41(typescript@5.9.3)):
+    dependencies:
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@5.9.3)
+
+  sitemapd@0.2.1:
+    dependencies:
+      fast-xml-parser: 5.10.1
 
   sitemapper@4.1.6:
     dependencies:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://reireias.dev/sitemap.xml

--- a/scripts/verify-performance-audit.mjs
+++ b/scripts/verify-performance-audit.mjs
@@ -4,6 +4,14 @@ import process from 'node:process'
 const REPORT_ROOT = '.unlighthouse/reports'
 const PUBLIC_PERFORMANCE_BUDGET = 60
 const SANDBOX_PERFORMANCE_BUDGET = 55
+const SEO_BUDGET = 100
+const INDEXABLE_ROUTES = new Set([
+  '/',
+  '/articles/',
+  '/experience/',
+  '/profile/',
+  '/skills/',
+])
 
 const formatMetric = (audit, divisor = 1, suffix = '') => {
   if (typeof audit?.numericValue !== 'number') return 'n/a'
@@ -33,7 +41,8 @@ const rows = await Promise.all(
   simpleReports.map(async (simpleReport) => {
     if (
       typeof simpleReport.path !== 'string' ||
-      !Number.isFinite(simpleReport.performance)
+      !Number.isFinite(simpleReport.performance) ||
+      !Number.isFinite(simpleReport.seo)
     ) {
       throw new Error('Unlighthouse produced an invalid route result')
     }
@@ -47,6 +56,8 @@ const rows = await Promise.all(
       path: simpleReport.path,
       performance: simpleReport.performance * 100,
       budget,
+      seo: simpleReport.seo * 100,
+      seoBudget: INDEXABLE_ROUTES.has(simpleReport.path) ? SEO_BUDGET : null,
       fcp: formatMetric(report.audits['first-contentful-paint'], 1000, 's'),
       lcp: formatMetric(report.audits['largest-contentful-paint'], 1000, 's'),
       tbt: formatMetric(report.audits['total-blocking-time'], 1, 'ms'),
@@ -60,11 +71,11 @@ const markdown = [
   '',
   'Scores and metrics use the median Lighthouse run from three mobile samples.',
   '',
-  '| Route | Performance | Budget | FCP | LCP | TBT | CLS |',
-  '| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
+  '| Route | Performance | Budget | SEO | SEO budget | FCP | LCP | TBT | CLS |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
   ...rows.map(
-    ({ path, performance, budget, fcp, lcp, tbt, cls }) =>
-      `| \`${path}\` | ${Math.round(performance)} | ${budget} | ${fcp} | ${lcp} | ${tbt} | ${cls} |`
+    ({ path, performance, budget, seo, seoBudget, fcp, lcp, tbt, cls }) =>
+      `| \`${path}\` | ${Math.round(performance)} | ${budget} | ${Math.round(seo)} | ${seoBudget ?? 'n/a'} | ${fcp} | ${lcp} | ${tbt} | ${cls} |`
   ),
   '',
 ].join('\n')
@@ -75,13 +86,17 @@ if (process.env.GITHUB_STEP_SUMMARY) {
   await appendFile(process.env.GITHUB_STEP_SUMMARY, markdown)
 }
 
-const failures = rows.filter(({ performance, budget }) => performance < budget)
+const failures = rows.filter(
+  ({ performance, budget, seo, seoBudget }) =>
+    performance < budget || (seoBudget !== null && seo < seoBudget)
+)
 
 if (failures.length > 0) {
   const details = failures
     .map(
-      ({ path, performance, budget }) => `${path}: ${performance} < ${budget}`
+      ({ path, performance, budget, seo, seoBudget }) =>
+        `${path}: Performance ${performance}/${budget}, SEO ${seo}/${seoBudget ?? 'n/a'}`
     )
     .join(', ')
-  throw new Error(`Performance budget failed: ${details}`)
+  throw new Error(`Audit budget failed: ${details}`)
 }

--- a/test/constants/seo.test.ts
+++ b/test/constants/seo.test.ts
@@ -1,0 +1,30 @@
+import { getCanonicalUrl, getPageSeo } from '@/constants/seo'
+
+describe('page SEO metadata', () => {
+  it('defines unique metadata for primary pages', () => {
+    const paths = ['/', '/profile', '/skills', '/experience', '/articles']
+    const metadata = paths.map(getPageSeo)
+
+    expect(new Set(metadata.map(({ title }) => title)).size).toBe(paths.length)
+    expect(new Set(metadata.map(({ description }) => description)).size).toBe(
+      paths.length
+    )
+    expect(metadata.every(({ robots }) => robots === undefined)).toBe(true)
+  })
+
+  it('keeps migrated URLs out of the index and points to their replacements', () => {
+    expect(getPageSeo('/job').robots).toBe('noindex, follow')
+    expect(getCanonicalUrl('/job')).toBe('https://reireias.dev/experience')
+    expect(getCanonicalUrl('/skill')).toBe('https://reireias.dev/skills')
+  })
+
+  it('prevents experimental and unknown pages from being indexed', () => {
+    expect(getPageSeo('/sandbox/anime').robots).toBe('noindex, follow')
+    expect(getPageSeo('/unknown').robots).toBe('noindex, follow')
+  })
+
+  it('normalizes trailing slashes to the canonical page URL', () => {
+    expect(getPageSeo('/profile/')).toEqual(getPageSeo('/profile'))
+    expect(getCanonicalUrl('/profile/')).toBe('https://reireias.dev/profile')
+  })
+})

--- a/test/e2e/seo.spec.ts
+++ b/test/e2e/seo.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test'
+
+test('primary pages expose unique metadata and canonical URLs', async ({
+  page,
+}) => {
+  await page.goto('/profile')
+
+  await expect(page).toHaveTitle('Profile | reireias')
+  await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+    'content',
+    'プリンシパルエンジニアとしての現在の仕事と、reireiasの個人プロフィールを紹介します。'
+  )
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+    'content',
+    'index, follow'
+  )
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://reireias.dev/profile'
+  )
+})
+
+test('migration and sandbox pages stay out of the index', async ({ page }) => {
+  await page.goto('/job')
+
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+    'content',
+    'noindex, follow'
+  )
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://reireias.dev/experience'
+  )
+
+  await page.goto('/sandbox/anime')
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+    'content',
+    'noindex, follow'
+  )
+})
+
+test('sitemap contains only primary public pages', async ({ request }) => {
+  const response = await request.get('/sitemap.xml')
+  const sitemap = await response.text()
+
+  expect(response.ok()).toBe(true)
+  for (const path of ['/', '/articles', '/experience', '/profile', '/skills']) {
+    expect(sitemap).toContain(`<loc>https://reireias.dev${path}</loc>`)
+  }
+  for (const path of ['/job', '/skill', '/template', '/sandbox']) {
+    expect(sitemap).not.toContain(`<loc>https://reireias.dev${path}</loc>`)
+  }
+})

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -32,7 +32,6 @@ export default defineUnlighthouseConfig({
       performance: 55,
       accessibility: 100,
       'best-practices': 100,
-      seo: 100,
     },
     reporter: 'json',
   },


### PR DESCRIPTION
## 概要

#561 Phase 3として、主要ページのSEOメタ情報、canonical、sitemap、構造化データを整備します。

Refs #561

## 変更内容

- 主要5ページへ固有のtitle / description / OGP URLを設定
- 全ルートへcanonical URLを設定し、旧`/job`・`/skill`は移行先をcanonicalに指定
- sandbox、template、旧URLを`noindex, follow`に設定
- `@nuxtjs/sitemap`のzero-runtime生成を導入し、主要5ページだけを掲載
- `robots.txt`からsitemapを案内
- トップページへPerson / ProfilePage / WebSiteのJSON-LDを追加
- 主要公開ページだけSEO 100を要求するようUnlighthouseゲートを調整
- SEOルート定義の単体テストと静的生成物のE2Eテストを追加

`@nuxtjs/seo`一式は導入せず、Nuxt標準の`useSeoMeta` / `useHead`と、必要な`@nuxtjs/sitemap`だけを採用しています。

## 検証

- [x] `pnpm ai:check`
- [x] `pnpm lint`
- [x] `pnpm lint:style`
- [x] `pnpm test --runInBand`（11件）
- [x] `pnpm generate`
- [x] `pnpm test:e2e`（19件）
- [x] `pnpm knip`
- [x] `pnpm audit:performance`

3サンプル中央値で、主要公開ページはPerformance 60〜62 / SEO 100。全ルートでTBT 0ms、CLS 0を維持しています。

## 補足

見た目の変更はないためスクリーンショットはありません。静的生成物でページ別メタ情報、canonical、JSON-LD、`sitemap.xml`、`robots.txt`を確認済みです。
