### PR TITLE
fix: definePageMetaのビルド警告を解消

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
   ],
   testPathIgnorePatterns: ['/node_modules/', '/test/e2e/'],
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/test/setup.ts'],
   testEnvironmentOptions: {
     customExportConditions: ['node', 'node-addons'],
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -213,9 +213,7 @@ import { computed } from 'vue'
 import articles from '@/constants/articles'
 import timeline from '@/constants/timeline'
 
-if (typeof definePageMeta !== 'undefined') {
-  definePageMeta({ layout: 'gridless' })
-}
+definePageMeta({ layout: 'gridless' })
 
 const featuredArticles = articles.filter((article) => article.featured)
 const workTimeline = computed(() =>

--- a/pages/sandbox/anime.vue
+++ b/pages/sandbox/anime.vue
@@ -194,6 +194,10 @@
   </AppContainer>
 </template>
 
+<script setup lang="ts">
+definePageMeta({ layout: 'gridless' })
+</script>
+
 <script lang="ts">
 import { defineComponent, ref, nextTick } from 'vue'
 import anime from 'animejs'
@@ -204,11 +208,6 @@ export default defineComponent({
     PageTitle,
   },
   setup() {
-    if (typeof definePageMeta !== 'undefined') {
-      definePageMeta({
-        layout: 'gridless',
-      })
-    }
     const ratio = 0.93
     const loops = 10
     let radius = 200

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,4 @@
+Object.defineProperty(globalThis, 'definePageMeta', {
+  value: () => undefined,
+  writable: true,
+})


### PR DESCRIPTION
## 概要

Nuxt 4.5の静的生成で発生していた `definePageMeta` の条件呼び出し警告を解消します。

## 変更内容

- トップページの `definePageMeta` をトップレベルで直接呼び出す
- sandbox/animeページのページメタ定義を `<script setup>` へ分離する
- Jest環境に `definePageMeta` のno-opを用意し、ページ単体テストとの互換性を維持する

## 確認内容

- `pnpm lint`
- `pnpm lint:style`
- `pnpm test --runInBand`
- `pnpm generate`（`NUXT_B4007` が出ないことを確認）
- `pnpm test:e2e`（19 tests passed）

Closes part of #561