### PR TITLE
perf: 生成フォントアセットを最適化

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,6 +43,12 @@ export default defineNuxtConfig({
   },
   css: ['@/assets/app.css'],
   modules: ['@nuxt/image', '@nuxt/ui', '@nuxtjs/sitemap'],
+  fonts: {
+    defaults: {
+      styles: ['normal'],
+      subsets: ['latin'],
+    },
+  },
   site: {
     url: 'https://reireias.dev',
     name: 'reireias.dev',


### PR DESCRIPTION
## 概要

Issue #561 Phase 4 のフォント最適化として、`@nuxt/fonts` が生成するフォントを実際の利用範囲へ限定します。

- style を normal に限定
- subset を latin に限定

## 改善結果

ローカル静的配信・mobile・3回計測の中央値で比較しました。

- 共通CSS: 約228 KB → 約194 KB
- `PageTitle` CSS: 約18.8 KB → 約2.7 KB
- `App` CSS: 約21.0 KB → 約4.9 KB
- 主要公開ページ Performance: 63〜65
- TBT: 全ルート 0 ms
- CLS: 全ルート 0
- Accessibility / Best Practices: 全ルート 100
- 主要公開ページ SEO: 全ルート 100

日本語グリフは従来どおりシステムフォントへフォールバックします。

## 検証

- `pnpm lint`
- `pnpm lint:style`
- `pnpm test --runInBand`
- `pnpm generate`
- `pnpm audit:performance`
- `pnpm test:e2e`

Closes part of #561