### PR TITLE
perf: 記事外部画像とLCPを最適化

### DIFF
--- a/components/ArticleCard.vue
+++ b/components/ArticleCard.vue
@@ -7,26 +7,19 @@
   >
     <div class="article-card__image">
       <NuxtPicture
-        v-if="article.image.startsWith('/')"
         :src="article.image"
         :alt="article.title"
         class="article-card__picture"
         format="avif,webp"
-        legacy-format="jpg"
+        legacy-format="webp"
         width="544"
         height="306"
         sizes="384px lg:544px"
-        loading="lazy"
-        :img-attrs="{ class: 'article-card__img' }"
-      />
-      <img
-        v-else
-        :src="article.image"
-        :alt="article.title"
-        class="article-card__img"
-        width="544"
-        height="306"
-        loading="lazy"
+        :loading="imageLoading"
+        :img-attrs="{
+          class: 'article-card__img',
+          fetchpriority: imageFetchPriority,
+        }"
       />
     </div>
     <div class="article-card__body">
@@ -49,7 +42,17 @@
 <script setup lang="ts">
 import type { Article } from '@/constants/articles'
 
-defineProps<{ article: Article }>()
+withDefaults(
+  defineProps<{
+    article: Article
+    imageLoading?: 'eager' | 'lazy'
+    imageFetchPriority?: 'auto' | 'high' | 'low'
+  }>(),
+  {
+    imageLoading: 'lazy',
+    imageFetchPriority: 'auto',
+  }
+)
 </script>
 
 <style scoped>

--- a/constants/articles.ts
+++ b/constants/articles.ts
@@ -27,7 +27,7 @@ const articles: Article[] = [
   {
     href: 'https://tech.medpeer.co.jp/entry/2025/10/27/091904',
     image:
-      'https://cdn.image.st-hatena.com/image/scale/9397139b32066115671a7279009670fe9e908d55/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fs%2Fsatoshitakumi%2F20251022%2F20251022175154.png',
+      'https://cdn-ak.f.st-hatena.com/images/fotolife/s/satoshitakumi/20251022/20251022175154.png',
     title: 'GitHub ActionsでTerraformを実行する',
     description:
       'Terraform CloudからGitHub Actionsへ、使い勝手や機能を維持しながら移行した工夫を紹介します。',
@@ -64,7 +64,7 @@ const articles: Article[] = [
   {
     href: 'https://speakerdeck.com/reireias/improving-efficiency-of-aws-account-operations-by-medpeer-sre-team',
     image:
-      'https://files.speakerdeck.com/presentations/bbcf01585b25479cb993975808c63709/slide_0.jpg?19573755',
+      'https://files.speakerdeck.com/presentations/bbcf01585b25479cb993975808c63709/slide_0.jpg',
     title: 'SREチームによるAWSアカウント運用効率化',
     description:
       '複数AWSアカウントの運用を、安全性を保ちながら効率化した取り組みです。',
@@ -102,7 +102,7 @@ const articles: Article[] = [
   {
     href: 'https://tech.medpeer.co.jp/entry/2020/11/24/090000',
     image:
-      'https://cdn.image.st-hatena.com/image/scale/709ac0af3746414e3fe0f9ca5bf308dd03a8fd4e/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fs%2Fsatoshitakumi%2F20201118%2F20201118153720.png',
+      'https://cdn-ak.f.st-hatena.com/images/fotolife/s/satoshitakumi/20201118/20201118153720.png',
     title: 'メドピアのECSデプロイ方法の変遷',
     description:
       'ECSの導入からデプロイ方式とタスク定義の管理方法を改善してきた変遷を紹介します。',
@@ -138,7 +138,7 @@ const articles: Article[] = [
   {
     href: 'https://tech.medpeer.co.jp/entry/2019/10/30/110000',
     image:
-      'https://cdn.image.st-hatena.com/image/scale/9487d55c93d0b9b22fa3693e1cced9d618db6ee6/backend=imagemagick;version=1;width=1300/https%3A%2F%2Fcdn-ak.f.st-hatena.com%2Fimages%2Ffotolife%2Fs%2Fsatoshitakumi%2F20191029%2F20191029102404.png',
+      'https://cdn-ak.f.st-hatena.com/images/fotolife/s/satoshitakumi/20191029/20191029102404.png',
     title: '半年間の開発環境の改善を振り返る',
     description:
       'Railsプロジェクトの実装と並行して進めた、開発環境の改善施策を振り返ります。',
@@ -161,7 +161,7 @@ const articles: Article[] = [
   {
     href: 'https://speakerdeck.com/reireias/medpeer-aws-seminar-ecs',
     image:
-      'https://files.speakerdeck.com/presentations/f93589dc55794dc8b722be041a7997d1/slide_0.jpg?672505',
+      'https://files.speakerdeck.com/presentations/f93589dc55794dc8b722be041a7997d1/slide_0.jpg',
     title: 'AWS勉強会 ECS編',
     description:
       'コンテナとECSの基礎から実運用までを解説した社内勉強会資料です。',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -49,6 +49,14 @@ export default defineNuxtConfig({
       subsets: ['latin'],
     },
   },
+  image: {
+    domains: [
+      'ogimage.blog.st-hatena.com',
+      'cdn-ak.f.st-hatena.com',
+      'd1.awsstatic.com',
+      'files.speakerdeck.com',
+    ],
+  },
   site: {
     url: 'https://reireias.dev',
     name: 'reireias.dev',

--- a/pages/articles.vue
+++ b/pages/articles.vue
@@ -12,9 +12,11 @@
     </div>
     <div class="article-grid">
       <ArticleCard
-        v-for="article in articles"
+        v-for="(article, index) in articles"
         :key="article.href"
         :article="article"
+        :image-loading="index === 0 ? 'eager' : 'lazy'"
+        :image-fetch-priority="index === 0 ? 'high' : 'auto'"
       />
     </div>
   </div>


### PR DESCRIPTION
## 概要

記事カードの外部画像もNuxt Image/IPXへ通し、AVIF/WebPのレスポンシブ静的アセットとして配信します。`/articles/` の先頭カードだけeager/highにし、2件目以降はlazyを維持しました。

Closes part of #561

## 変更内容

- `ArticleCard` に `imageLoading` / `imageFetchPriority` APIを追加
- ローカル・外部画像を `NuxtPicture` に統一
- 外部画像ドメインを4ドメインへ限定
- 先頭カードのみ `loading="eager"` / `fetchpriority="high"`
- 2件目以降は `loading="lazy"` / `fetchpriority="auto"`
- クエリやネストURLを含む配信URLを、静的ホスティングで404にならない元画像URLへ正規化

## 静的生成の確認

- `dist/_ipx/**`: 124ファイル、約3.0MB
- AVIF/WebP、384/544pxと2x相当の768/1088pxを生成
- 生成HTMLに外部URLへの直接リクエストはなく、`/_ipx/**` を参照
- 全13画像にwidth/heightと16:9の表示領域を維持

## ローカル監査比較

mobile・各ルート3サンプル中央値です。beforeは #589 マージ時の値です。

| Route | Performance before | after | LCP before | after | TBT | CLS |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `/articles/` | 79 | 86 | 4.43s | 3.30s | 0ms | 0 |

Accessibility / Best Practices / SEO は100を維持しています。監査時の総転送量は404KiBでした。

## 検証

- `pnpm lint`
- `pnpm lint:style`
- `pnpm test --runInBand`（8 suites / 11 tests）
- `pnpm generate`
- `pnpm audit:performance`（10 routes / 3 samples、budget成功）
- `pnpm test:e2e`（19 tests）
