### PR TITLE
chore: sandboxをパフォーマンス監査から除外

### DIFF
--- a/docs/performance-audit.md
+++ b/docs/performance-audit.md
@@ -19,20 +19,21 @@ and audits every configured route with mobile throttling. Each route is measured
 three times, and Unlighthouse selects the median Lighthouse run. The result table
 includes Performance, SEO, FCP, LCP, TBT, and CLS.
 
-The regression budgets are deliberately separated by route type:
+The regression budgets are:
 
 - Main public routes: Performance 60+
-- `/sandbox/**`: Performance 55+
 - All routes: Accessibility and Best Practices 100
 - Indexable routes (`/`, `/articles/`, `/experience/`, `/profile/`, `/skills/`):
   SEO 100
 
-Sandbox pages contain experimental code and are not part of the final 95+ target,
-and migration, sandbox, and template pages are intentionally marked `noindex`.
-Lighthouse lowers the SEO score for `noindex`, so those routes are excluded only
-from the SEO score gate; their other category and performance budgets still prevent
-major regressions. The budgets should be raised in small steps after improvements
-consistently pass multiple CI runs.
+Sandbox pages contain experimental code and are excluded from the performance
+audit. Their page-specific JavaScript and CSS remain split into route-level chunks
+by Nuxt. Migration, sandbox, and template pages are intentionally marked `noindex`.
+For configured migration and template routes, Lighthouse lowers the SEO score for
+`noindex`, so those routes are excluded only from the SEO score gate; their other
+category and performance budgets still prevent major regressions. The budgets
+should be raised in small steps after improvements consistently pass multiple CI
+runs.
 
 GitHub Actions uploads `.unlighthouse/` as the `unlighthouse-report` artifact and
 adds the page-by-page table to the job summary.

--- a/scripts/verify-performance-audit.mjs
+++ b/scripts/verify-performance-audit.mjs
@@ -3,7 +3,6 @@ import process from 'node:process'
 
 const REPORT_ROOT = '.unlighthouse/reports'
 const PUBLIC_PERFORMANCE_BUDGET = 60
-const SANDBOX_PERFORMANCE_BUDGET = 55
 const SEO_BUDGET = 100
 const INDEXABLE_ROUTES = new Set([
   '/',
@@ -23,11 +22,6 @@ const getReportPath = (routePath) => {
   const relativePath = routePath === '/' ? '' : routePath.replace(/^\//, '')
   return `${REPORT_ROOT}/${relativePath}lighthouse.json`
 }
-
-const getBudget = (routePath) =>
-  routePath.startsWith('/sandbox/') || routePath === '/sandbox/'
-    ? SANDBOX_PERFORMANCE_BUDGET
-    : PUBLIC_PERFORMANCE_BUDGET
 
 const simpleReports = JSON.parse(
   await readFile('.unlighthouse/ci-result.json', 'utf8')
@@ -50,12 +44,10 @@ const rows = await Promise.all(
     const report = JSON.parse(
       await readFile(getReportPath(simpleReport.path), 'utf8')
     )
-    const budget = getBudget(simpleReport.path)
-
     return {
       path: simpleReport.path,
       performance: simpleReport.performance * 100,
-      budget,
+      budget: PUBLIC_PERFORMANCE_BUDGET,
       seo: simpleReport.seo * 100,
       seoBudget: INDEXABLE_ROUTES.has(simpleReport.path) ? SEO_BUDGET : null,
       fcp: formatMetric(report.audits['first-contentful-paint'], 1000, 's'),

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -8,8 +8,6 @@ export default defineUnlighthouseConfig({
     '/experience/',
     '/job/',
     '/profile/',
-    '/sandbox/',
-    '/sandbox/anime/',
     '/skill/',
     '/skills/',
     '/template/',
@@ -29,7 +27,7 @@ export default defineUnlighthouseConfig({
   },
   ci: {
     budget: {
-      performance: 55,
+      performance: 60,
       accessibility: 100,
       'best-practices': 100,
     },


### PR DESCRIPTION
## 概要

- Unlighthouseの計測対象から `/sandbox/` と `/sandbox/anime/` を除外
- Sandbox専用のPerformance予算を削除し、設定済みルートを60へ統一
- NuxtによるSandbox固有JS/CSSのルート単位分割について監査ドキュメントへ明記

## 検証

- `pnpm lint`
- `pnpm test --runInBand`
- `pnpm audit:performance`
- `node scripts/verify-performance-audit.mjs`

ローカル監査では8ルートのみが計測され、`/sandbox/**` が結果に含まれないことを確認しました。