### PR TITLE
ci: パフォーマンス監査とE2Eを並列化

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ jobs:
       - run: pnpm nuxi prepare
       - run: pnpm test
 
-  e2e-test:
+  performance-audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -65,6 +65,21 @@ jobs:
           path: .unlighthouse/
           include-hidden-files: true
           retention-days: 30
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.20.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.19.0'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm generate
       - name: Run Playwright E2E tests
         run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm test:e2e
       - name: Upload Playwright report


### PR DESCRIPTION
## 概要

- Unlighthouse監査を `performance-audit` ジョブへ分離
- Playwrightの `e2e-test` と依存関係なしで並列実行
- E2Eジョブ自身で静的サイトを生成し、監査ジョブへの暗黙依存を解消
- 両ジョブのtimeoutを10分に設定
- 既存のUnlighthouse / Playwright artifact uploadを維持
- masterにbranch protectionがないためrequired check設定変更は不要

Closes #590

## Actions検証

Run `31452040910` で4ジョブが同時に開始され、すべて成功しました。

| Job | Before | After |
| --- | ---: | ---: |
| E2E結果の確定 | 約4分2秒（監査後） | 1分19秒 |
| Performance audit | E2Eジョブ内 | 3分35秒 |
| lint | 独立 | 47秒 |
| unit test | 独立 | 45秒 |

- `unlighthouse-report`: 生成済み
- `playwright-report`: 生成済み
- 監査とE2Eの失敗箇所は別checkとして判別可能

## ローカル検証

- `pnpm lint`
- `pnpm lint:style`
- `pnpm test --runInBand`（8 suites / 11 tests）
- `pnpm audit:performance`（8 routes / 3 samples、budget成功）
- `pnpm generate`
- `pnpm test:e2e`（19 tests）